### PR TITLE
Keep the description and code consistent about quotes

### DIFF
--- a/docs/art/81vue-lexical-analysis.md
+++ b/docs/art/81vue-lexical-analysis.md
@@ -206,7 +206,7 @@ console.log('disabled'.match(attribute))  // 测试无属性值
 ```js
 // 对于单引号的情况
 [
-    'class="some-class"',
+    "class='some-class'",
     'class',
     '=',
     undefined,
@@ -215,7 +215,7 @@ console.log('disabled'.match(attribute))  // 测试无属性值
 ]
 // 对于没有引号
 [
-    'class="some-class"',
+    'class=some-class',
     'class',
     '=',
     undefined,


### PR DESCRIPTION
Description is single quote but codes are all double quotes.
