### PR TITLE
fix: 添加新元素漏掉了从末尾添加的情况

### DIFF
--- a/docs/zh/renderer-diff.md
+++ b/docs/zh/renderer-diff.md
@@ -1036,14 +1036,21 @@ while (oldStartIdx <= oldEndIdx && newStartIdx <= newEndIdx) {
 
 此时 `oldEndIdx` 的值将变成 `-1`，它要小于 `oldStartIdx` 的值，这时循环的条件不在满足，意味着更新完成。然而通过上图可以很容易的发现 `li-d` 节点被遗漏了，它没有得到任何的处理，通过这个案例我们意识到了之前的算法是存在缺陷的，为了弥补这个缺陷，我们需要在循环终止之后，对 `oldEndIdx` 和 `oldStartIdx` 的值进行检查，如果在循环结束之后 `oldEndIdx` 的值小于 `oldStartIdx` 的值则说明新的 `children` 中存在**还没有被处理的全新节点**，这时我们应该调用 `mount` 函数将其挂载到容器元素中，观察上图可知，我们只需要把这些全新的节点添加到 `oldStartIdx` 索引所指向的节点之前即可，如下高亮代码所示：
 
-```js {4-9}
+```js {4-16}
 while (oldStartIdx <= oldEndIdx && newStartIdx <= newEndIdx) {
   // 省略...
 }
 if (oldEndIdx < oldStartIdx) {
   // 添加新节点
   for (let i = newStartIdx; i <= newEndIdx; i++) {
-    mount(nextChildren[i], container, false, oldStartVNode.el)
+    mount(
+      nextChildren[i],
+      container,
+      false,
+      oldStartVNode
+        ? oldStartVNode.el
+        : oldEndVNode.el.nextSibling
+    )
   }
 }
 ```


### PR DESCRIPTION
如果在末尾添加元素,前面三个双端比较后,退出了循环,此时oldStartIdx为3,oldEndIdx为2,`prevChildren`中不存在索引为3的子节点,所以此时`oldStartVNode`为`undefined`,也不存在`el`属性,所以这个时候应该去抓old节点的最后一项`oldEndVNode`,将新增元素添加到`oldEndVNode.el.nextSibling`前面
```javascript
const preT = h('div', '', [
  h('div', { key: 'a' }, 'a'),
  h('div', { key: 'b' }, 'b'),
  h('div', { key: 'c' }, 'c')
]);
const curT = h('div', '', [
  h('div', { key: 'a' }, 'a'),
  h('div', { key: 'b' }, 'b'),
  h('div', { key: 'c' }, 'c'),
  h('div', { key: 'd' }, 'd')
]);

render(preT, document.getElementById('app'));
setTimeout(() => {
  render(curT, document.getElementById('app'));
}, 1000);
```