### PR TITLE
fix 修改最长递归子序列dome错误

### DIFF
--- a/docs/zh/renderer-diff.md
+++ b/docs/zh/renderer-diff.md
@@ -1850,7 +1850,7 @@ if (moved) {
 :::
 
 :::tip
-完整代码&在线体验地址：[https://codesandbox.io/s/32wjmo7omq](https://codesandbox.io/s/32wjmo7omq)
+完整代码&在线体验地址：[https://codesandbox.io/s/lis-forked-zp38j](https://codesandbox.io/s/lis-forked-zp38j)
 :::
 
 ## 不足之处


### PR DESCRIPTION
最长递归子序列dome这块， 这个用例没通过[20, 8, 4, 12, 2, 1]，按照大佬的思路实在没有想出来怎么处理，所以重写了一个。